### PR TITLE
Fix str/byte type errors

### DIFF
--- a/pysap/utils/fields.py
+++ b/pysap/utils/fields.py
@@ -234,7 +234,7 @@ class StrEncodedPaddedField(StrField):
                  fmt="H", remain=0):
         StrField.__init__(self, name, default, fmt, remain)
         self.encoding = encoding
-        self.padd = padd
+        self.padd = padd.encode() if isinstance(padd, str) else padd
 
     def h2i(self, pkt, x):
         if x:
@@ -252,7 +252,7 @@ class StrEncodedPaddedField(StrField):
     def getfield(self, pkt, s):
         l = s.find(self.padd)
         if l < 0:
-            return "", s
+            return b"", s
         return s[l + 1:], self.m2i(pkt, s[:l])
 
 
@@ -273,7 +273,7 @@ class PacketListStopField(PacketListField):
             c = self.count_from(pkt)
 
         lst = []
-        ret = ""
+        ret = b""
         remain = s
         if l is not None:
             remain, ret = s[:l], s[l:]
@@ -288,14 +288,14 @@ class PacketListStopField(PacketListField):
                 if conf.debug_dissector:
                     raise
                 p = conf.raw_layer(load=remain)
-                remain = ""
+                remain = b""
             else:
                 if conf.padding_layer in p:
                     pad = p[conf.padding_layer]
                     remain = pad.load
                     del (pad.underlayer.payload)
                 else:
-                    remain = ""
+                    remain = b""
             lst.append(p)
             # Evaluate the stop condition
             if self.stop and self.stop(p):

--- a/tests/fields_test.py
+++ b/tests/fields_test.py
@@ -21,9 +21,12 @@ import unittest
 from datetime import datetime
 # External imports
 from scapy.asn1.asn1 import ASN1_Error
+from scapy.fields import StrFixedLenField
+from scapy.packet import Packet
 # Custom imports
 from pysap.utils.fields import (saptimestamp_to_datetime, StrNullFixedLenField,
                                 StrFixedLenPaddedField, StrNullFixedLenPaddedField,
+                                StrEncodedPaddedField, PacketListStopField,
                                 AdjustableFieldLenField, ASN1F_CHOICE_SAFE)
 
 
@@ -53,6 +56,12 @@ class RejectingChoice(object):
 
     def __init__(self, s, _underlayer=None):
         raise ASN1_Error("rejecting choice")
+
+
+class FixedLengthTestPacket(Packet):
+    fields_desc = [
+        StrFixedLenField("value", b"", length=2),
+    ]
 
 
 class PySAPUtilsFieldsTest(unittest.TestCase):
@@ -105,6 +114,25 @@ class PySAPUtilsFieldsTest(unittest.TestCase):
         remaining, value = field.getfield(pkt, b"ab\x00xyrest")
         self.assertEqual(remaining, b"rest")
         self.assertEqual(value, b"ab")
+
+    def test_str_encoded_padded_field_accepts_text_padding(self):
+        field = StrEncodedPaddedField("value", None, encoding="utf-8", padd="\x0c")
+
+        raw = field.addfield(None, b"", "abc")
+        remaining, value = field.getfield(None, raw + b"rest")
+
+        self.assertEqual(raw, b"abc\x0c")
+        self.assertEqual(remaining, b"rest")
+        self.assertEqual(value, b"abc")
+
+    def test_packet_list_stop_field_returns_bytes_remainder(self):
+        field = PacketListStopField("items", None, FixedLengthTestPacket, length_from=lambda pkt: 2)
+
+        remaining, value = field.getfield(None, b"abrest")
+
+        self.assertEqual(remaining, b"rest")
+        self.assertEqual(len(value), 1)
+        self.assertEqual(value[0].value, b"ab")
 
     def test_adjustable_field_len_field_short_and_extended(self):
         field = AdjustableFieldLenField("length", None, length_of="payload")


### PR DESCRIPTION
While using https://github.com/SecuritySilverbacks/sncscan with this pysap library, I ran into an issue where TypeErrors were raised to due a mismatch between String and Bytes.
Scapy operates on byte buffers, and pysap sometimes returns a string.

I encountered it in StrEncodedPaddedField and fixed it similar to the sibling classes StrFixedLenPaddedField and StrNullFixedLenPaddedField.
In addition, there are two more spots in the code where a byte should be returned.